### PR TITLE
[feat] 1. 사용자 개인정보 암호화 적용 2. 로그인 세션 24시간 적용

### DIFF
--- a/app/(auth)/loginpage/additionalinfo/page.tsx
+++ b/app/(auth)/loginpage/additionalinfo/page.tsx
@@ -33,7 +33,7 @@ export default function AdditionalInfoPage() {
   const [loading, setLoading] = useState(false)
   const [hasEmailFromProvider, setHasEmailFromProvider] = useState(false)
 
-  const today = new Date().toISOString().split('T')[0]
+  const today = new Date().toLocaleDateString('en-CA')
 
   // 소셜 로그인 정보를 기본값으로 설정
   useEffect(() => {

--- a/app/(auth)/loginpage/additionalinfo/page.tsx
+++ b/app/(auth)/loginpage/additionalinfo/page.tsx
@@ -33,6 +33,8 @@ export default function AdditionalInfoPage() {
   const [loading, setLoading] = useState(false)
   const [hasEmailFromProvider, setHasEmailFromProvider] = useState(false)
 
+  const today = new Date().toISOString().split('T')[0]
+
   // 소셜 로그인 정보를 기본값으로 설정
   useEffect(() => {
     if (session?.user) {
@@ -192,6 +194,7 @@ export default function AdditionalInfoPage() {
             <input
               type="date"
               value={formData.birthDate}
+              max={today}
               onChange={(e) => setFormData({ ...formData, birthDate: e.target.value })}
               className="w-full p-2 border rounded"
               required

--- a/app/api/party/report/route.ts
+++ b/app/api/party/report/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/lib/supabase";
 import { auth } from "@/lib/auth";
+import { decryptText } from '@/lib/crypto'
 
 type PartyReportPayload = {
   partyId?: string | number;
@@ -85,9 +86,8 @@ export async function POST(request: NextRequest) {
       .eq("id", session.user.id)
       .maybeSingle();
 
-    const partyChairmanName = ownerData?.name?.trim() || "알 수 없음";
-    const reporterName =
-      (session.user.name?.trim() || reporterData?.name?.trim()) ?? "알 수 없음";
+    const partyChairmanName = decryptText(ownerData?.name)?.trim() || "알 수 없음";
+    const reporterName = (session.user.name?.trim() || decryptText(reporterData?.name)?.trim()) ?? "알 수 없음";
 
     const { error: insertError } = await supabase
       .from("party_reports")

--- a/app/api/user/updateprofile/route.ts
+++ b/app/api/user/updateprofile/route.ts
@@ -1,6 +1,7 @@
 // app/api/user/updateprofile/route.ts
 import { NextResponse } from 'next/server'
 import { getSupabaseAdminClient } from '@/lib/supabase'  // ← 이걸 import!
+import { encryptText } from '@/lib/crypto'
 
 const supabase = getSupabaseAdminClient()  // ← Admin 클라이언트 사용!
 
@@ -16,11 +17,11 @@ export async function POST(request: Request) {
     const { data, error } = await supabase
       .from('users')
       .update({
-        name,
-        email,
+        name: encryptText(name),
+        email: encryptText(email),
         gender,
-        phone: phone.replace(/-/g, ''),
-        birth_date: birthDate,
+        phone: encryptText(phone.replace(/-/g, '')),
+        birth_date: encryptText(birthDate),
         is_profile_complete: true,
       })
       .eq('id', userId)

--- a/components/header/slidepanel.tsx
+++ b/components/header/slidepanel.tsx
@@ -1,7 +1,6 @@
 // src/components/header/slidepanel.tsx
 'use client';
 
-import { supabase } from '@/lib/clientSupabase';
 import { TextSkeleton } from '@/components/ui/text-skeleton';
 import clsx from 'clsx';
 import { useSession } from 'next-auth/react';
@@ -45,22 +44,7 @@ export default function SlidePanel({ isopen, onclose, title, children }: slidepa
             return;
          }
 
-         // ⭐ Option 2: users 테이블에서 이름 가져오기 (세션에 없을 때)
-
-         const { data: userData, error: userError } = await supabase
-            .from('users')
-            .select('name')
-            .eq('id', session.user.id)
-            .single();
-
-
-         if (userError) {
-            console.error('⚠️ users 테이블 조회 실패:', userError);
-            setUserName(session.user.email?.split('@')[0] || '사용자');
-            return;
-         }
-
-         const displayName = userData?.name || session.user.email?.split('@')[0] || '사용자';
+         const displayName = session.user.name || session.user.email?.split('@')[0] || '사용자';
 
          setUserName(displayName);
       } catch (error) {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -2,6 +2,7 @@
 import NextAuth from "next-auth"
 import KakaoProvider from "next-auth/providers/kakao"
 import { createClient } from '@supabase/supabase-js'
+import { decryptText } from '@/lib/crypto'
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -35,7 +36,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
         if (existingUser) {
           user.id = existingUser.id
-          user.name = existingUser.name || user.name
+          user.name = decryptText(existingUser.name) || user.name
           user.image = existingUser.image_url || user.image
           return true
         }
@@ -76,8 +77,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
         if (dbUser) {
           token.id = dbUser.id
-          token.name = dbUser.name
-          token.email = dbUser.email
+          token.name = decryptText(dbUser.name)
+          token.email = decryptText(dbUser.email)
           token.picture = dbUser.image_url
           token.isProfileComplete = dbUser.is_profile_complete
           token.role = dbUser.role
@@ -116,5 +117,9 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   },
   session: {
     strategy: "jwt",
+    maxAge: 24 * 60 * 60, // 24시간
+  },
+  jwt: {
+    maxAge: 24 * 60 * 60, // 24시간
   },
 })

--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -26,20 +26,28 @@ export function encryptText(value: string | null | undefined) {
 export function decryptText(value: string | null | undefined) {
   if (!value) return null
 
-  const payload = JSON.parse(value)
+  try {
+    const payload = JSON.parse(value)
+    if (typeof payload !== 'object' || payload === null || !payload.iv || !payload.tag || !payload.data) {
+      return value
+    }
 
-  const decipher = crypto.createDecipheriv(
-    'aes-256-gcm',
-    key,
-    Buffer.from(payload.iv, 'base64')
-  )
+    const decipher = crypto.createDecipheriv(
+      'aes-256-gcm',
+      key,
+      Buffer.from(payload.iv, 'base64')
+    )
 
-  decipher.setAuthTag(Buffer.from(payload.tag, 'base64'))
+    decipher.setAuthTag(Buffer.from(payload.tag, 'base64'))
 
-  const decrypted = Buffer.concat([
-    decipher.update(Buffer.from(payload.data, 'base64')),
-    decipher.final(),
-  ])
+    const decrypted = Buffer.concat([
+      decipher.update(Buffer.from(payload.data, 'base64')),
+      decipher.final(),
+    ])
 
-  return decrypted.toString('utf8')
+    return decrypted.toString('utf8')
+  } catch (error) {
+    // JSON 파싱 에러(평문) 또는 복호화 실패 시 원본 반환
+    return value
+  }
 }

--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -1,0 +1,45 @@
+// 암호화 유틸
+import crypto from 'crypto'
+
+const key = Buffer.from(process.env.DATA_ENCRYPTION_KEY!, 'base64')
+
+export function encryptText(value: string | null | undefined) {
+  if (!value) return null
+
+  const iv = crypto.randomBytes(12)
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv)
+
+  const encrypted = Buffer.concat([
+    cipher.update(value, 'utf8'),
+    cipher.final(),
+  ])
+
+  const tag = cipher.getAuthTag()
+
+  return JSON.stringify({
+    iv: iv.toString('base64'),
+    tag: tag.toString('base64'),
+    data: encrypted.toString('base64'),
+  })
+}
+
+export function decryptText(value: string | null | undefined) {
+  if (!value) return null
+
+  const payload = JSON.parse(value)
+
+  const decipher = crypto.createDecipheriv(
+    'aes-256-gcm',
+    key,
+    Buffer.from(payload.iv, 'base64')
+  )
+
+  decipher.setAuthTag(Buffer.from(payload.tag, 'base64'))
+
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(payload.data, 'base64')),
+    decipher.final(),
+  ])
+
+  return decrypted.toString('utf8')
+}


### PR DESCRIPTION
🔧 작업 내용
- 로그인 세션 만료 시간을 24시간으로 설정
- 사용자 개인정보(name, email, phone, birth_date) 암호화 저장 처리
- 암호화된 사용자 이름/이메일을 세션 및 신고 처리 시 복호화하도록 반영
- 생년월일 입력 시 오늘 이후 날짜를 선택할 수 없도록 제한

🧩 구현 상세 (선택)
- NextAuth `session.maxAge`, `jwt.maxAge`를 24시간으로 설정
- `crypto` 기반 AES-256-GCM 암복호화 유틸 추가
- 프로필 저장 API에서 개인정보 컬럼을 암호화하여 저장
- 인증 콜백 및 신고 API에서 필요한 사용자명을 복호화하여 사용
- 암호화 저장을 위해 개인정보 컬럼 타입을 text로 변경

📌 관련 Jira Issue
KAN-2-be-24-loginsession

🧪 테스트 방법(선택)
- 로그인 후 24시간 세션 설정이 적용되는지 확인
- 추가정보 입력 페이지에서 개인정보 저장 성공 확인
- Supabase `users` 테이블에서 개인정보가 암호문으로 저장되는지 확인
- 로그아웃 후 재로그인 시 이름/이메일이 정상 표시되는지 확인
- 파티 신고 시 신고자명/파티장명이 정상 저장되는지 확인
- 생년월일에서 오늘 이후 날짜 선택이 제한되는지 확인

❗ 참고 사항
- `DATA_ENCRYPTION_KEY` 환경변수 설정이 필요함
- 암호화 대상 컬럼은 `text` 타입이어야 함
- 기존 평문 데이터가 있는 경우 별도 마이그레이션 또는 안전 복호화 처리가 필요함

Fixes: KAN-2-be-24-loginsession