### PR TITLE
fix: alert를 toast로 수정

### DIFF
--- a/app/(auth)/loginpage/additionalinfo/page.tsx
+++ b/app/(auth)/loginpage/additionalinfo/page.tsx
@@ -5,8 +5,11 @@ import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import { useState, useEffect } from 'react'
 import { LoadingBounce } from '@/components/status/LoadingBounce'
+import { useToast } from '@/contexts/ToastContext';
 
 export default function AdditionalInfoPage() {
+  const { showToast } = useToast();
+
   // 휴대전화 포맷 변경
   const onlyNumbers = (value: string) => value.replace(/\D/g, '')
   const formatPhoneNumber = (value: string) => {
@@ -92,11 +95,11 @@ export default function AdditionalInfoPage() {
         window.location.href = '/'
       } else {
         console.error('서버 에러:', responseData)
-        alert(`정보 저장에 실패했습니다: ${responseData.error}`)
+        showToast(`정보 저장에 실패했습니다: ${responseData.error}`);
       }
     } catch (error) {
       console.error('Error:', error)
-      alert('오류가 발생했습니다.')
+      showToast('오류가 발생했습니다.');
     } finally {
       setLoading(false)
     }

--- a/components/partyrow/PartyRow.tsx
+++ b/components/partyrow/PartyRow.tsx
@@ -64,19 +64,19 @@ export function PartyRow({
    const handleSubmitReport = async () => {
       if (isSubmitting) return;
       if (!partyId) {
-         alert('파티 정보를 찾을 수 없어요.');
+         showToast('파티 정보를 찾을 수 없어요.');
          return;
       }
       if (!reportCategory) {
-         alert('카테고리를 선택해주세요.');
+         showToast('카테고리를 선택해주세요.');
          return;
       }
       if (!reportContent.trim()) {
-         alert('신고 내용을 입력해주세요.');
+         showToast('신고 내용을 입력해주세요.');
          return;
       }
       if (!reportDate) {
-         alert('발생 일시를 입력해주세요.');
+         showToast('발생 일시를 입력해주세요.');
          return;
       }
 
@@ -104,7 +104,7 @@ export function PartyRow({
          setIsReportOpen(false);
       } catch (error) {
          console.error('파티 신고 실패:', error);
-         alert(error instanceof Error ? error.message : '파티 신고에 실패했어요.');
+         showToast(error instanceof Error ? error.message : '파티 신고에 실패했어요.');
       } finally {
          setIsSubmitting(false);
       }

--- a/components/photo/photo.tsx
+++ b/components/photo/photo.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import { ChangeEvent, useEffect, useRef, useState } from "react";
 import { Input } from "../ui/input";
 import { Button } from "../ui/button";
+import { useToast } from '@/contexts/ToastContext';
 
 /**
  * @component
@@ -31,6 +32,8 @@ export const PhotoInputContainer = ({
   uploadImage: (file: File) => Promise<number>;
   autoScroll?: boolean;
 }): React.ReactElement => {
+  const { showToast } = useToast();
+
   const [images, setImages] = useState<string[] | null>(initImages);
 
   const PhotoInput = () => {
@@ -39,11 +42,11 @@ export const PhotoInputContainer = ({
       const file = event.target.files?.[0];
       if (file) {
         if (file.size > 5 * 1024 * 1024) {
-          alert("파일 크기가 너무 큽니다 (최대 5MB).");
+          showToast("파일 크기가 너무 큽니다 (최대 5MB).");
           return;
         }
         if (!["image/jpeg", "image/png", "image/gif"].includes(file.type)) {
-          alert("JPEG, PNG, GIF 이미지 파일만 업로드할 수 있습니다.");
+          showToast("JPEG, PNG, GIF 이미지 파일만 업로드할 수 있습니다.");
           return;
         }
 
@@ -59,7 +62,7 @@ export const PhotoInputContainer = ({
           console.error("[PhotoInput] 에러가 발생했습니다:", error);
         }
       } else {
-        alert("오류로 인해 이미지 파일 추가에 실패했습니다.");
+        showToast("오류로 인해 이미지 파일 추가에 실패했습니다.");
         console.error("[PhotoInput Error] image file is not exist : ", file);
       }
     };
@@ -165,6 +168,8 @@ export const PhotoEditable = ({
   onChange?: (file: File, previewUrl: string) => void;
   className?: string;
 }): React.ReactElement => {
+  const { showToast } = useToast();
+
   const [previewUrl, setPreviewUrl] = useState(imageUrl);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -190,11 +195,11 @@ export const PhotoEditable = ({
     }
 
     if (file.size > 5 * 1024 * 1024) {
-      alert("파일 크기가 너무 큽니다 (최대 5MB).");
+      showToast("파일 크기가 너무 큽니다 (최대 5MB).");
       return;
     }
     if (!["image/jpeg", "image/png", "image/gif"].includes(file.type)) {
-      alert("JPEG, PNG, GIF 이미지 파일만 업로드할 수 있습니다.");
+      showToast("JPEG, PNG, GIF 이미지 파일만 업로드할 수 있습니다.");
       return;
     }
 

--- a/components/toast/toast.tsx
+++ b/components/toast/toast.tsx
@@ -16,11 +16,12 @@ export default function Toast({ message, className = "" }: ToastProps) {
     return (
         <div
             className={[
-                "flex flex-col items-center justify-center gap-4",
-                "px-4 py-6 rounded-[16px]",
-                "bg-[#F1F5FA]",
-                "text-[24px] font-regular text-center",
-                "w-[600px] h-[65px]"
+                "flex min-h-12 w-[calc(100vw-32px)] max-w-[420px] items-center justify-center",
+                "rounded-[12px] border border-[#DCE3EB] bg-white px-4 py-3",
+                "text-center text-[15px] font-medium leading-relaxed text-[#04152F]",
+                "shadow-[0_8px_24px_rgba(4,21,47,0.14)]",
+                "break-keep",
+                className
             ].join(" ")}
         >
             {message}

--- a/components/ui/Map/MapSection.tsx
+++ b/components/ui/Map/MapSection.tsx
@@ -16,6 +16,7 @@ import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { MapPinOff } from 'lucide-react';
 import { BiTargetLock } from 'react-icons/bi';
+import { useToast } from '@/contexts/ToastContext';
 
 const REGION_NAME = {
    all: null,
@@ -90,6 +91,8 @@ const REGION_BUTTONS = [
 ];
 
 const MapSection = () => {
+   const { showToast } = useToast();
+
    const map = useMapStore(state => state.map);
    const isMapScriptLoaded = useMapStore(state => state.isMapScriptLoaded);
    const isInitialFetchDone = useRef(false);
@@ -621,7 +624,7 @@ const MapSection = () => {
       if (!map) return;
 
       if (!navigator.geolocation) {
-         alert(`현재 위치를 사용할 수 없습니다.`);
+         showToast(`현재 위치를 사용할 수 없습니다.`);
          return;
       }
 
@@ -656,7 +659,7 @@ const MapSection = () => {
          },
          (error) => {
             console.error(`현재 위치 가져오기 실패:`, error);
-            alert('현재 위치 권한을 확인해주세요.');
+            showToast('현재 위치 권한을 확인해주세요.');
          },
          {
             enableHighAccuracy: true,

--- a/feature/admin/UserReportDialog.tsx
+++ b/feature/admin/UserReportDialog.tsx
@@ -3,6 +3,7 @@ import { TwoFunctionPopup } from '@/components/popup/twofunction';
 import { Button } from '@/components/ui/button/button';
 import { PartyReportData, UserReportData } from '@/types/userReport';
 import { useState } from 'react';
+import { useToast } from '@/contexts/ToastContext';
 
 interface UserReportDialogProps {
    reportData: UserReportData | PartyReportData;
@@ -13,6 +14,8 @@ interface UserReportDialogProps {
 }
 
 export function UserReportDialog({ reportData, onUpdate, type = 'user-report' }: UserReportDialogProps) {
+   const { showToast } = useToast();
+
    const reportCategoryLabels: Record<string, string> = {
       cult_activity: '사이비 포교 활동',
       unauthorized_commercial: '미허가 영리활동',
@@ -122,7 +125,7 @@ export function UserReportDialog({ reportData, onUpdate, type = 'user-report' }:
 
    const handleApply = async () => {
       if (!sanctionType) {
-         alert('제재 유형을 선택해주세요.');
+         showToast('제재 유형을 선택해주세요.');
          return;
       }
 

--- a/feature/admin/addEventDialog.tsx
+++ b/feature/admin/addEventDialog.tsx
@@ -7,12 +7,15 @@ import { Button } from '@/components/ui/button/button';
 import { useState } from 'react';
 import { AddressSearchDialog } from './addressSearchDialog';
 import { supabase } from '@/lib/clientSupabase';
+import { useToast } from '@/contexts/ToastContext';
 
 interface AddEventProps {
    onAddEvent: (formData: any) => Promise<void>;
 }
 
 export function AddEvent({ onAddEvent }: AddEventProps) {
+   const { showToast } = useToast();
+
    const [eventName, setEventName] = useState('');
    const [eventImages, setEventImages] = useState<string[]>([]);
    const [eventIntro, setEventIntro] = useState('');
@@ -62,16 +65,16 @@ export function AddEvent({ onAddEvent }: AddEventProps) {
 
    const handleAdd = async () => {
       if (!eventName.trim()) {
-         alert('이벤트 명을 입력해주세요.');
+         showToast('이벤트 명을 입력해주세요.');
          return;
       }
       if (!startDate || !endDate) {
-         alert('이벤트 기간을 입력해주세요.');
+         showToast('이벤트 기간을 입력해주세요.');
          return;
       }
 
       if (uploadingImage) {
-         alert('이미지 업로드 중입니다. 잠시만 기다려주세요.');
+         showToast('이미지 업로드 중입니다. 잠시만 기다려주세요.');
          return;
       }
 
@@ -148,7 +151,7 @@ export function AddEvent({ onAddEvent }: AddEventProps) {
          return 200;
       } catch (error) {
          console.error('❌ 이미지 처리 에러:', error);
-         alert('이미지 업로드 중 오류가 발생했습니다.');
+         showToast("이미지 업로드 중 오류가 발생했습니다.");
          return 400;
       } finally {
          setUploadingImage(false);
@@ -166,14 +169,6 @@ export function AddEvent({ onAddEvent }: AddEventProps) {
          return newHosts;
       });
    };
-
-   // const handleHostDelete = (index: number) => {
-   //    if (hosts.length <= 1) {
-   //       alert('주최사는 최소 1개 이상 입력해야합니다.');
-   //       return;
-   //    }
-   //    setHosts(prev => prev.filter((_, i) => i !== index));
-   // };
 
    const handleAddressSearch = () => {
       setIsAddressSearchOpen(true);

--- a/feature/admin/addEventDialog.tsx
+++ b/feature/admin/addEventDialog.tsx
@@ -151,7 +151,7 @@ export function AddEvent({ onAddEvent }: AddEventProps) {
          return 200;
       } catch (error) {
          console.error('❌ 이미지 처리 에러:', error);
-         showToast("이미지 업로드 중 오류가 발생했습니다.");
+         showToast('이미지 업로드 중 오류가 발생했습니다.');
          return 400;
       } finally {
          setUploadingImage(false);

--- a/feature/admin/addNoticeDialog.tsx
+++ b/feature/admin/addNoticeDialog.tsx
@@ -24,6 +24,7 @@ import Color from '@tiptap/extension-color';
 import Highlight from '@tiptap/extension-highlight';
 import { TextStyle } from '@tiptap/extension-text-style';
 import { RiResetLeftFill } from 'react-icons/ri';
+import { useToast } from '@/contexts/ToastContext';
 
 type MenuBarProps = {
    editor: Editor | null;
@@ -227,6 +228,8 @@ interface AddNoticeProps {
 }
 
 export function AddNotice({ onAddNotice }: AddNoticeProps) {
+   const { showToast } = useToast();
+   
    const [isEmpty, setIsEmpty] = useState(true);
    const [category, setCategory] = useState('normal');
    const [isTopFixed, setIsTopFixed] = useState(false);
@@ -261,12 +264,12 @@ export function AddNotice({ onAddNotice }: AddNoticeProps) {
 
    const handleAdd = async () => {
       if (!title.trim()) {
-         alert('제목을 입력해주세요.');
+         showToast("제목을 입력해주세요.");
          return;
       }
 
       if (!editor || editor.isEmpty) {
-         alert('내용을 입력해주세요.');
+         showToast("내용을 입력해주세요.");
          return;
       }
 
@@ -285,29 +288,10 @@ export function AddNotice({ onAddNotice }: AddNoticeProps) {
          setIsTopFixed(false);
          editor?.commands.clearContent();
 
-         alert('공지사항이 등록되었습니다.');
+         showToast("공지사항이 등록되었습니다.");
       } catch (error) {
          console.error('등록 실패:', error);
       }
-
-      // // API
-      // try {
-      //    const response = await fetch('/api/notices', {
-      //       method: 'POST',
-      //       headers: { 'Content-Type': 'application/json' },
-      //       body: JSON.stringify(noticeData),
-      //    });
-      //    if (response.ok) {
-      //       alert('공지사항이 등록되었습니다.');
-      //       setTitle('');
-      //       setCategory('normal');
-      //       setIsTopFixed(false);
-      //       editor?.commands.clearContent();
-      //    }
-      // } catch (error) {
-      //    console.error('등록 실패:', error);
-      //    alert('등록에 실패했습니다.');
-      // }
    };
 
    return (

--- a/feature/admin/addressSearchDialog.tsx
+++ b/feature/admin/addressSearchDialog.tsx
@@ -2,6 +2,7 @@ import { OneFunctionPopup } from '@/components/popup/onefunction';
 import { Button } from '@/components/ui/button';
 import { SearchBar } from '@/components/ui/searchBar';
 import { useState } from 'react';
+import { useToast } from '@/contexts/ToastContext';
 
 interface AddressSearchDialogProps {
    isOpen: boolean;
@@ -18,6 +19,8 @@ interface PlaceResult {
 }
 
 export function AddressSearchDialog({ isOpen, onOpenChange, onSelectAddress }: AddressSearchDialogProps) {
+   const { showToast } = useToast();
+
    const [searchQuery, setSearchQuery] = useState('');
    const [searchResults, setSearchResults] = useState<PlaceResult[]>([]);
    const [isSearching, setIsSearching] = useState(false);
@@ -25,7 +28,7 @@ export function AddressSearchDialog({ isOpen, onOpenChange, onSelectAddress }: A
 
    const handleSearch = async () => {
       if (!searchQuery.trim()) {
-         alert('검색어를 입력해주세요.');
+         showToast('검색어를 입력해주세요.');
          return;
       }
       setIsSearching(true);
@@ -67,11 +70,11 @@ export function AddressSearchDialog({ isOpen, onOpenChange, onSelectAddress }: A
             setSelectedIndex(null);
          } else {
             setSearchResults([]);
-            alert('검색 결과가 없습니다.');
+            showToast('검색 결과가 없습니다.');
          }
       } catch (error) {
          console.error('❌ [프론트] 검색 실패:', error);
-         alert('주소 검색 중 오류가 발생했습니다.');
+         showToast('주소 검색 중 오류가 발생했습니다.');
          setSearchResults([]);
       } finally {
          setIsSearching(false);
@@ -80,7 +83,7 @@ export function AddressSearchDialog({ isOpen, onOpenChange, onSelectAddress }: A
 
    const handleSelectAddress = () => {
       if (selectedIndex === null) {
-         alert('주소를 선택해주세요.');
+         showToast('주소를 선택해주세요.');
          return;
       }
 

--- a/feature/admin/editEventDialog.tsx
+++ b/feature/admin/editEventDialog.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button/button';
 import { useEffect, useState } from 'react';
 import { AddressSearchDialog } from './addressSearchDialog';
 import { supabase } from '@/lib/clientSupabase';
+import { useToast } from '@/contexts/ToastContext';
 
 interface EditEventProps {
    event: any | null;
@@ -17,6 +18,8 @@ interface EditEventProps {
 }
 
 export function EditEvent({ event, isOpen, onClose, onEditEvent, onDeleteEvent }: EditEventProps) {
+   const { showToast } = useToast();
+
    const [eventName, setEventName] = useState('');
    const [eventImages, setEventImages] = useState<string[]>([]);
    const [eventIntro, setEventIntro] = useState('');
@@ -155,7 +158,7 @@ export function EditEvent({ event, isOpen, onClose, onEditEvent, onDeleteEvent }
          return 200;
       } catch (error) {
          console.error('❌ 이미지 처리 에러:', error);
-         alert('이미지 업로드 중 오류가 발생했습니다.');
+         showToast('이미지 업로드 중 오류가 발생했습니다.');
          return 400;
       } finally {
          setUploadingImage(false);
@@ -164,16 +167,16 @@ export function EditEvent({ event, isOpen, onClose, onEditEvent, onDeleteEvent }
 
    const handleEdit = async () => {
       if (!eventName.trim()) {
-         alert('이벤트 명을 입력해주세요.');
+         showToast('이벤트 명을 입력해주세요.');
          return;
       }
       if (!startDate || !endDate) {
-         alert('이벤트 기간을 입력해주세요.');
+         showToast('이벤트 기간을 입력해주세요.');
          return;
       }
 
       if (uploadingImage) {
-         alert('이미지 업로드 중입니다. 잠시만 기다려주세요.');
+         showToast('이미지 업로드 중입니다. 잠시만 기다려주세요.');
          return;
       }
 
@@ -209,23 +212,11 @@ export function EditEvent({ event, isOpen, onClose, onEditEvent, onDeleteEvent }
       }
    };
 
-   // const handleHostAdd = () => {
-   //    setHosts(prev => [...prev, '']);
-   // };
-
    const handleHostChange = (index: number, value: string) => {
       const newHosts = [...hosts];
       newHosts[index] = value;
       setHosts(newHosts);
    };
-
-   // const handleHostDelete = (index: number) => {
-   //    if (hosts.length <= 1) {
-   //       alert('주최사는 최소 1개 이상 입력해야합니다.');
-   //       return;
-   //    }
-   //    setHosts(prev => prev.filter((_, i) => i !== index));
-   // };
 
    const handleAddressSearch = () => {
       setIsAddressSearchOpen(true);

--- a/feature/admin/editNoticeDialog.tsx
+++ b/feature/admin/editNoticeDialog.tsx
@@ -23,6 +23,7 @@ import { TextStyle } from '@tiptap/extension-text-style';
 import { RiResetLeftFill } from 'react-icons/ri';
 import { NoticeData } from '@/types/userReport';
 import { TwoFunctionPopup } from '@/components/popup/twofunction';
+import { useToast } from '@/contexts/ToastContext';
 
 type MenuBarProps = {
    editor: Editor | null;
@@ -230,6 +231,8 @@ interface EditNoticeProps {
 }
 
 export function EditNotice({ notice, isOpen, onClose, onEditNotice, onDeleteNotice }: EditNoticeProps) {
+   const { showToast } = useToast();
+
    const [isEmpty, setIsEmpty] = useState(true);
    const [category, setCategory] = useState('normal');
    const [isTopFixed, setIsTopFixed] = useState(false);
@@ -277,12 +280,12 @@ export function EditNotice({ notice, isOpen, onClose, onEditNotice, onDeleteNoti
 
    const handleEdit = async () => {
       if (!title.trim()) {
-         alert('제목을 입력해주세요.');
+         showToast('제목을 입력해주세요.');
          return;
       }
 
       if (!editor || editor.isEmpty) {
-         alert('내용을 입력해주세요.');
+         showToast('내용을 입력해주세요.');
          return;
       }
 
@@ -305,29 +308,10 @@ export function EditNotice({ notice, isOpen, onClose, onEditNotice, onDeleteNoti
 
          onClose();
 
-         alert('공지사항이 등록되었습니다.');
+         showToast('공지사항이 등록되었습니다.');
       } catch (error) {
          console.error('등록 실패:', error);
       }
-
-      // // API
-      // try {
-      //    const response = await fetch('/api/notices', {
-      //       method: 'POST',
-      //       headers: { 'Content-Type': 'application/json' },
-      //       body: JSON.stringify(noticeData),
-      //    });
-      //    if (response.ok) {
-      //       alert('공지사항이 등록되었습니다.');
-      //       setTitle('');
-      //       setCategory('normal');
-      //       setIsTopFixed(false);
-      //       editor?.commands.clearContent();
-      //    }
-      // } catch (error) {
-      //    console.error('등록 실패:', error);
-      //    alert('등록에 실패했습니다.');
-      // }
    };
 
    const handleDelete = async () => {
@@ -341,7 +325,7 @@ export function EditNotice({ notice, isOpen, onClose, onEditNotice, onDeleteNoti
       try {
          await onDeleteNotice(notice.id);
          onClose();
-         alert('공지사항이 삭제되었습니다.');
+         showToast('공지사항이 삭제되었습니다.');
       } catch (error) {
          console.error('공지사항 삭제 실패:', error);
       }

--- a/feature/admin/editNoticeDialog.tsx
+++ b/feature/admin/editNoticeDialog.tsx
@@ -308,7 +308,7 @@ export function EditNotice({ notice, isOpen, onClose, onEditNotice, onDeleteNoti
 
          onClose();
 
-         showToast('공지사항이 등록되었습니다.');
+         showToast('공지사항이 수정되었습니다.');
       } catch (error) {
          console.error('등록 실패:', error);
       }

--- a/feature/admin/event.tsx
+++ b/feature/admin/event.tsx
@@ -11,8 +11,11 @@ import { EventData, EventDisplayData, EventImage } from '@/types/userReport';
 import { Input } from '@/components/ui/input';
 import { EditEvent } from './editEventDialog';
 import { supabase } from '@/lib/clientSupabase';
+import { useToast } from '@/contexts/ToastContext';
 
 export default function Event() {
+   const { showToast } = useToast();
+
    const [events, setEvents] = useState<EventData[]>([]);
    const [loading, setLoading] = useState(true);
    const [currentPage, setCurrentPage] = useState(1);
@@ -70,7 +73,7 @@ export default function Event() {
          setEvents(data || []);
       } catch (error) {
          console.error('이벤트 조회 실패:', error);
-         alert('이벤트 목록을 불러오는데 실패하였습니다.');
+         showToast('이벤트 목록을 불러오는데 실패하였습니다.');
       } finally {
          setLoading(false);
       }
@@ -258,10 +261,10 @@ export default function Event() {
             setEvents(prev => [{ ...newEvent, event_images: [] }, ...prev]);
          }
          setCurrentPage(1);
-         alert('이벤트가 등록되었습니다.');
+         showToast('이벤트가 등록되었습니다.');
       } catch (error) {
          console.error('이벤트 등록 실패:', error);
-         alert('이벤트 등록에 실패했습니다.');
+         showToast('이벤트 등록에 실패했습니다.');
          throw error;
       }
    };
@@ -330,10 +333,10 @@ export default function Event() {
          }
 
          fetchEvents();
-         alert('이벤트가 수정되었습니다.');
+         showToast('이벤트가 수정되었습니다.');
       } catch (error) {
          console.error('이벤트 수정 실패:', error);
-         alert('이벤트 수정에 실패했습니다.');
+         showToast('이벤트 수정에 실패했습니다.');
          throw error;
       }
    };
@@ -374,10 +377,10 @@ export default function Event() {
             setCurrentPage(newTotalPages);
          }
 
-         alert('이벤트가 삭제되었습니다.');
+         showToast('이벤트가 삭제되었습니다.');
       } catch (error) {
          console.error('이벤트 삭제 실패:', error);
-         alert('이벤트 삭제에 실패했습니다.');
+         showToast('이벤트 삭제에 실패했습니다.');
       }
    };
 

--- a/feature/admin/notice.tsx
+++ b/feature/admin/notice.tsx
@@ -11,8 +11,11 @@ import { NoticeData, NoticeDisplayData } from '@/types/userReport';
 import { Input } from '@/components/ui/input';
 import { supabase } from '@/lib/clientSupabase';
 import { EditNotice } from './editNoticeDialog';
+import { useToast } from '@/contexts/ToastContext';
 
 export default function Notice() {
+   const { showToast } = useToast();
+
    const [notices, setNotices] = useState<NoticeData[]>([]);
    const [loading, setLoading] = useState(true);
    const [currentPage, setCurrentPage] = useState(1);
@@ -41,7 +44,7 @@ export default function Notice() {
          setNotices(data || []);
       } catch (error) {
          console.error('공지사항 조회 실패:', error);
-         alert('공지사항 목록을 불러오는데 실패하였습니다.');
+         showToast('공지사항 목록을 불러오는데 실패하였습니다.');
       } finally {
          setLoading(false);
       }
@@ -154,10 +157,10 @@ export default function Notice() {
 
          setNotices(prev => [newNotice, ...prev]);
          setCurrentPage(1);
-         alert('공지사항이 등록되었습니다.');
+         showToast('공지사항이 등록되었습니다.');
       } catch (error) {
          console.error('공지사항 등록 실패:', error);
-         alert('공지사항 등록에 실패했습니다.');
+         showToast('공지사항 등록에 실패했습니다.');
          throw error;
       }
    };
@@ -190,10 +193,10 @@ export default function Notice() {
             .single();
 
          setNotices(prev => prev.map(notice => (notice.id === originalNotice.id ? updatedNotice : notice)));
-         alert('공지사항이 수정되었습니다.');
+         showToast('공지사항이 수정되었습니다.');
       } catch (error) {
          console.error('공지사항 수정 실패:', error);
-         alert('공지사항 수정에 실패했습니다.');
+         showToast('공지사항 수정에 실패했습니다.');
          throw error;
       }
    };
@@ -211,10 +214,10 @@ export default function Notice() {
          if (currentPage > newTotalPages && newTotalPages > 0) {
             setCurrentPage(newTotalPages);
          }
-         alert('공지사항이 삭제되었습니다.');
+         showToast('공지사항이 삭제되었습니다.');
       } catch (error) {
          console.error('공지사항 삭제 실패:', error);
-         alert('공지사항 삭제에 실패했습니다.');
+         showToast('공지사항 삭제에 실패했습니다.');
          throw error;
       }
    };

--- a/feature/admin/party-report.tsx
+++ b/feature/admin/party-report.tsx
@@ -10,8 +10,11 @@ import { UserReportDialog } from './UserReportDialog';
 import { PartyReportData } from '@/types/userReport';
 import { Input } from '@/components/ui/input';
 import { supabase } from '@/lib/clientSupabase';
+import { useToast } from '@/contexts/ToastContext';
 
 export default function PartyReport() {
+   const { showToast } = useToast();
+
    const [reports, setReports] = useState<PartyReportData[]>([]);
    const [loading, setLoading] = useState(true);
    const [currentPage, setCurrentPage] = useState(1);
@@ -66,7 +69,7 @@ export default function PartyReport() {
          setReports(normalized);
       } catch (error) {
          console.error('파티 신고 조회 실패:', error);
-         alert('파티 신고 목록을 불러오는데 실패하였습니다.');
+         showToast('파티 신고 목록을 불러오는데 실패하였습니다.');
       } finally {
          setLoading(false);
       }
@@ -173,10 +176,10 @@ export default function PartyReport() {
          // 로컬 상태 업데이트
          setReports(prev => prev.map(report => (report.id === reportId ? { ...report, ...updateData } : report)));
 
-         alert('제재 정보가 업데이트되었습니다.');
+         showToast('제재 정보가 업데이트되었습니다.');
       } catch (error) {
          console.error('파티 신고 업데이트 실패:', error);
-         alert('업데이트에 실패했습니다.');
+         showToast('업데이트에 실패했습니다.');
          throw error;
       }
    };

--- a/feature/admin/user-report.tsx
+++ b/feature/admin/user-report.tsx
@@ -10,8 +10,11 @@ import { UserReportDialog } from './UserReportDialog';
 import { UserReportData } from '@/types/userReport';
 import { Input } from '@/components/ui/input';
 import { supabase } from '@/lib/clientSupabase';
+import { useToast } from '@/contexts/ToastContext';
 
 export default function UserReport() {
+   const { showToast } = useToast();
+
    const [reports, setReports] = useState<UserReportData[]>([]);
    const [loading, setLoading] = useState(true);
    const [currentPage, setCurrentPage] = useState(1);
@@ -64,7 +67,7 @@ export default function UserReport() {
          setReports(normalized);
       } catch (error) {
          console.error('신고 조회 실패:', error);
-         alert('신고 목록을 불러오는데 실패하였습니다.');
+         showToast('신고 목록을 불러오는데 실패하였습니다.');
       } finally {
          setLoading(false);
       }
@@ -141,10 +144,10 @@ export default function UserReport() {
          if (error) throw error;
 
          setReports(prev => prev.map(report => (report.id === reportId ? { ...report, ...updateData } : report)));
-         alert('제재 정보가 업데이트되었습니다.');
+         showToast('제재 정보가 업데이트되었습니다.');
       } catch (error) {
          console.error('신고 업데이트 실패:', error);
-         alert('업데이트에 실패했습니다.');
+         showToast('업데이트에 실패했습니다.');
          throw error;
       }
    };

--- a/feature/event/detail/PartyDrawer.tsx
+++ b/feature/event/detail/PartyDrawer.tsx
@@ -9,6 +9,7 @@ import { RadioComponent } from "@/components/basic/radio";
 import { TwoFunctionPopup } from "@/components/popup/twofunction";
 import { Icon24 } from "@/components/icons/icon24";
 import { getSocket } from "@/lib/socket";
+import { useToast } from '@/contexts/ToastContext';
 
 interface PartyDrawerProps {
     eventId: string; // 이벤트 아이디
@@ -63,6 +64,8 @@ const REPORT_CATEGORIES = [
 }));
 
 export function PartyDrawer({ name }: PartyDrawerProps) {
+    const { showToast } = useToast();
+
     const { data: session } = useSession(); // 로그인 세션
     const isLoggedIn = !!session?.user?.id; // 유저 아이디가 있으면 로그인 상태
 
@@ -189,7 +192,7 @@ export function PartyDrawer({ name }: PartyDrawerProps) {
 
             if (!res.ok) throw new Error("Report API Request Fail");
 
-            alert("신고가 접수되었습니다.");
+            showToast("신고가 접수되었습니다.");
         } catch (error) {
             console.error("Report Data Loading Fail:", error);
         }
@@ -198,14 +201,14 @@ export function PartyDrawer({ name }: PartyDrawerProps) {
     // 메시지 전송
     const handleSend = () => {
         if (!socket.connected) {
-            alert("서버와 연결되지 않았습니다.");
+            showToast("서버와 연결되지 않았습니다.");
             return;
         }
 
         if (!input.trim() || !session?.user?.id || !session?.user?.name) return;
 
         if (input.length > 100) {
-            alert("메시지는 100자 이내로 작성해주세요.");
+            showToast("메시지는 100자 이내로 작성해주세요.");
             return;
         }
 
@@ -229,27 +232,27 @@ export function PartyDrawer({ name }: PartyDrawerProps) {
 
         try {
             if (!reportCategory) {
-                alert("카테고리를 선택해주세요.");
+                showToast("카테고리를 선택해주세요.");
                 return;
             }
 
             if (!reportContent.trim()) {
-                alert("사유를 입력해주세요.");
+                showToast("사유를 입력해주세요.");
                 return;
             }
 
             if (!session?.user?.id) {
-                alert("로그인이 필요합니다.");
+                showToast("로그인이 필요합니다.");
                 return;
             }
 
             if (reportContent.length > 100) {
-                alert("내용을 100자 이내로 작성해주세요.");
+                showToast("내용을 100자 이내로 작성해주세요.");
                 return;
             }
 
             if (addOpinion.length > 100) {
-                alert("추가 의견을 100자 이내로 작성해주세요.");
+                showToast("추가 의견을 100자 이내로 작성해주세요.");
                 return;
             }
 
@@ -302,7 +305,7 @@ export function PartyDrawer({ name }: PartyDrawerProps) {
 
         const handleRoomFull = (payload: RoomFullPayload) => {
             const { roomId, limit } = payload;
-            alert(`'${roomId}' 방은 이미 ${limit}명으로 가득 찼습니다!`);
+            showToast(`'${roomId}' 방은 이미 ${limit}명으로 가득 찼습니다!`);
         };
 
 

--- a/feature/location/search/RouteSearchBody.tsx
+++ b/feature/location/search/RouteSearchBody.tsx
@@ -193,7 +193,7 @@ export const RouteSearchBody = ({}: {}) => {
 
   const search = async () => {
     if (places.length < 2) {
-      alert("출발지와 목적지를 모두 선택해주세요.");
+      showToast("출발지와 목적지를 모두 선택해주세요.");
       return;
     }
 
@@ -204,7 +204,7 @@ export const RouteSearchBody = ({}: {}) => {
       const endPlace = places.find((p) => p.order === places.length);
 
       if (!startPlace || !endPlace) {
-        alert("출발지 또는 목적지 정보가 부족합니다.");
+        showToast("출발지 또는 목적지 정보가 부족합니다.");
         return;
       }
       const routeData = await getTransPath(startPlace, endPlace);
@@ -249,7 +249,7 @@ export const RouteSearchBody = ({}: {}) => {
       }
     } catch (error: any) {
       console.error("길찾기 중 오류 발생:", error.message);
-      alert(`길찾기 실패: ${error.message}`);
+      showToast(`길찾기 실패: ${error.message}`);
       setRoutePoints([]);
     } finally {
       setIsDuringSearching(false);
@@ -338,7 +338,7 @@ export const RouteSearchBody = ({}: {}) => {
     if (!map || !isMapScriptLoaded) return;
 
     if (!mapObj) {
-      alert(
+      showToast(
         "현재 선택하신 대중교통(KTX, ITX, SRT, 시외 버스 등)은 도보 및 지하철&시내버스 경로를 제외한 지도 경로 정보를 제공하지 않습니다.\n추후 업데이트를 통해 해당 내용은 제공될 예정입니다."
       );
       fallbackPolylinesRef.current.push(...drawFallbackSegments(map, subPaths));

--- a/feature/login/withdrawbutton.tsx
+++ b/feature/login/withdrawbutton.tsx
@@ -3,8 +3,11 @@
 
 import { withdrawUser } from '@/feature/login/withdraw'
 import { signOut } from 'next-auth/react'
+import { useToast } from '@/contexts/ToastContext';
 
 export default function WithdrawButton() {
+  const { showToast } = useToast();
+
   const handleWithdraw = async () => {
     if (!confirm('정말 탈퇴하시겠습니까?')) {
       return
@@ -14,7 +17,7 @@ export default function WithdrawButton() {
       await withdrawUser()
       await signOut({ callbackUrl: '/' })
     } catch (error) {
-      alert('탈퇴 처리 중 오류가 발생했습니다.')
+      showToast('탈퇴 처리 중 오류가 발생했습니다.')
     }
   }
 

--- a/feature/party/partyCreatePopup.tsx
+++ b/feature/party/partyCreatePopup.tsx
@@ -8,6 +8,7 @@ import { createParty } from "@/lib/party/party";
 import { useEffect, useState } from "react";
 import { EventSearchBar } from "../event/EventSearchBar";
 import { PlaceSearchBar } from "../location/search/PlaceSearchBar";
+import { useToast } from '@/contexts/ToastContext';
 
 export type PartyCreate = {
   partyName: string;
@@ -38,6 +39,8 @@ export const PartyCreatePopup = ({
   initialData,
   allowOutsideInteraction = false,
 }: PartyCreatePopupProps) => {
+  const { showToast } = useToast();
+
   const [create, setCreate] = useState<PartyCreate>({
     partyName: "",
     max_members: "",
@@ -119,31 +122,31 @@ export const PartyCreatePopup = ({
     }
 
     if (!create.partyName.trim()) {
-      alert("파티명을 입력해주세요.");
+      showToast("파티명을 입력해주세요.");
       return;
     }
     if (!create.eventName?.trim() || !create.eventId || create.eventId <= 0) {
-      alert("이벤트명을 입력해주세요.");
+      showToast("이벤트명을 입력해주세요.");
       return;
     }
     if (!create.max_members || parseInt(create.max_members) < 1) {
-      alert("최대 인원을 입력해주세요.");
+      showToast("최대 인원을 입력해주세요.");
       return;
     }
     if (!create.location?.trim()) {
-      alert("장소를 입력해주세요.");
+      showToast("장소를 입력해주세요.");
       return;
     }
     if (!create.date) {
-      alert("날짜를 입력해주세요.");
+      showToast("날짜를 입력해주세요.");
       return;
     }
     if (!create.time) {
-      alert("시간을 입력해주세요.");
+      showToast("시간을 입력해주세요.");
       return;
     }
     if (!create.description?.trim()) {
-      alert("파티 소개를 입력해주세요.");
+      showToast("파티 소개를 입력해주세요.");
       return;
     }
     if (!isFormValid) return;
@@ -152,7 +155,7 @@ export const PartyCreatePopup = ({
       await createParty(createWithTag);
     } catch (error) {
       console.error("파티 생성 실패:", error);
-      alert(
+      showToast(
         error instanceof Error
           ? error.message
           : "파티 생성에 실패했어요. 잠시 후 다시 시도해주세요."


### PR DESCRIPTION
🔧 작업 내용
alert로 되어 있는 사용자 알림을 공통 toast로 변경

🧩 구현 상세
- window.alert 호출을 ToastContext의 showToast 호출로 교체
- 필요한 컴포넌트에 useToast hook 연결
- 기존 공통 ToastProvider 구조를 유지하여 알림 표시 방식 통일

📌 관련 Jira Issue
KAN-4-fe-toast

🧪 테스트 방법
- npm run lint
- npm run build
- 주요 알림 발생 플로우에서 toast 노출 확인

❗ 참고 사항
- 주석 처리된 alert 코드는 변경하지 않음
- confirm 등 사용자 선택이 필요한 브라우저 팝업은 이번 범위에 포함하지 않음

Fixes: KAN-4-fe-toast